### PR TITLE
add set proxy setting support

### DIFF
--- a/src/auto/network_proxy_settings.rs
+++ b/src/auto/network_proxy_settings.rs
@@ -18,6 +18,14 @@ glib_wrapper! {
 }
 
 impl NetworkProxySettings {
+    pub fn new(default_proxy_uri: &str, ignore_hosts: &[&str]) -> NetworkProxySettings {
+        assert_initialized_main_thread!();
+        unsafe {
+            // *mut WebKitNetworkProxySettings
+            from_glib_none(webkit2_sys::webkit_network_proxy_settings_new(default_proxy_uri.to_glib_none().0, ignore_hosts.to_glib_none().0))
+        }
+    }
+
     #[cfg(any(feature = "v2_16", feature = "dox"))]
     pub fn add_proxy_for_scheme(&mut self, scheme: &str, proxy_uri: &str) {
         unsafe {

--- a/src/auto/web_context.rs
+++ b/src/auto/web_context.rs
@@ -5,6 +5,9 @@
 use gio;
 use gio_sys;
 use glib;
+use crate::auto::NetworkProxyMode;
+use crate::auto::network_proxy_settings::NetworkProxySettings;
+
 use glib::object::Cast;
 use glib::object::IsA;
 use glib::signal::connect_raw;
@@ -256,6 +259,8 @@ pub trait WebContextExt: 'static {
     #[cfg_attr(feature = "v2_26", deprecated)]
     #[cfg(any(feature = "v2_10", feature = "dox"))]
     fn set_web_process_count_limit(&self, limit: u32);
+
+    fn set_network_proxy_settings(&self, proxy_mode: NetworkProxyMode, proxy_settings: &mut NetworkProxySettings);
 
     #[cfg_attr(feature = "v2_10", deprecated)]
     #[cfg(any(feature = "v2_8", feature = "dox"))]
@@ -558,6 +563,17 @@ impl<O: IsA<WebContext>> WebContextExt for O {
     fn set_web_process_count_limit(&self, limit: u32) {
         unsafe {
             webkit2_sys::webkit_web_context_set_web_process_count_limit(self.as_ref().to_glib_none().0, limit);
+        }
+    }
+
+    // https://webkitgtk.org/reference/webkit2gtk/stable/WebKitWebContext.html#webkit-web-context-set-network-proxy-settings
+    fn set_network_proxy_settings(&self, proxy_mode: NetworkProxyMode, proxy_settings: &mut NetworkProxySettings) {
+        unsafe {
+            webkit2_sys::webkit_web_context_set_network_proxy_settings(
+                self.as_ref().to_glib_none().0,
+                proxy_mode.to_glib(),
+                proxy_settings.to_glib_none_mut().0,
+            );
         }
     }
 


### PR DESCRIPTION
as https://github.com/gtk-rs/webkit2gtk-rs/issues/81#issuecomment-868668956

this PR add the ability to setup proxy settings for context

demo usage code:

```rust
fn create_web_context(http_proxy: Option<String>) -> WebContext {
    let web_data_manager = WebsiteDataManagerBuilder::new();

    let web_context = WebContextBuilder::new().
		website_data_manager(&web_data_manager).
		build();

    if let Some(proxy_uri) = http_proxy {

        let mut proxy_setting = NetworkProxySettings::new("", &[]);
        proxy_setting.add_proxy_for_scheme("http", proxy_uri.as_str());
        proxy_setting.add_proxy_for_scheme("https", proxy_uri.as_str());

        web_context.set_network_proxy_settings(NetworkProxyMode::Custom, &mut proxy_setting);
        log::info!("set_network_proxy_settings http proxy: {}", proxy_uri);
    }
}
```