### PR TITLE
Fix transfer rule of `URISchemeRequest::http_headers` to none

### DIFF
--- a/.changes/transfer-none.md
+++ b/.changes/transfer-none.md
@@ -1,0 +1,6 @@
+---
+"webkit2gtk-rs": patch
+---
+
+Fix transfer rule of `URISchemeRequest::http_headers` to none.
+

--- a/src/auto/uri_scheme_request.rs
+++ b/src/auto/uri_scheme_request.rs
@@ -110,7 +110,10 @@ impl<O: IsA<URISchemeRequest>> URISchemeRequestExt for O {
 
   fn http_headers(&self) -> Option<soup::MessageHeaders> {
     unsafe {
-      from_glib_full(ffi::webkit_uri_scheme_request_get_http_headers(
+      // XXX: Gir file is incorrect with `transfer: full`. We do this fix internally
+      // so it can just be patch bump. When we update gir and generate new bindings next
+      // time. Please make sure it's fixed. Or we should add a manual external trait.
+      from_glib_none(ffi::webkit_uri_scheme_request_get_http_headers(
         self.as_ref().to_glib_none().0,
       ))
     }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
