### PR TITLE
Fix transfer rule of `URISchemeResponse::set_http_headers`

### DIFF
--- a/.changes/transfer-full.md
+++ b/.changes/transfer-full.md
@@ -1,0 +1,5 @@
+---
+"webkit2gtk-rs": patch
+---
+
+Fix transfer rule of `URISchemeResponse::set_http_headers` to full.

--- a/src/auto/uri_scheme_response.rs
+++ b/src/auto/uri_scheme_response.rs
@@ -144,7 +144,10 @@ impl<O: IsA<URISchemeResponse>> URISchemeResponseExt for O {
     unsafe {
       ffi::webkit_uri_scheme_response_set_http_headers(
         self.as_ref().to_glib_none().0,
-        headers.to_glib_none_mut().0,
+        // XXX: Gir file is incorrect with `transfer: none`. We do this fix internally
+        // so it can just be patch bump. When we update gir and generate new bindings next
+        // time. Please make sure it's fixed. Or we should add a manual external trait.
+        headers.to_glib_full() as *mut _,
       );
     }
   }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?
<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?
<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [x] When resolving issues, they are referenced in the PR's title (e.g `fix #___, #___`)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
