### PR TITLE
bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webkit2gtk"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 categories = [ "api-bindings", "gui" ]
 description = "Rust bindings for webkit-gtk library"
@@ -19,11 +19,6 @@ name = "webkit2gtk"
 [features]
 dox = [
   "ffi/dox",
-  "gtk/dox",
-  "glib/dox",
-  "gio/dox",
-  "gdk/dox",
-  "soup/dox",
   "java_script_core/dox"
 ]
 v2_2 = [ ]
@@ -51,26 +46,26 @@ v2_40 = [ "v2_38", "ffi/v2_40" ]
 bitflags = "^1.0"
 once_cell = "1.8"
 libc = "^0.2"
-cairo-rs = "^0.16.0"
-gdk = "^0.16.0"
-gdk-sys = "^0.16.0"
-gio = "^0.16.0"
-gio-sys = "^0.16.0"
-glib = "^0.16.0"
-glib-sys = "^0.16.0"
-gobject-sys = "^0.16.0"
-gtk = "^0.16.0"
-gtk-sys = "^0.16.0"
+cairo-rs = "^0.18.0"
+gdk = "^0.18.0"
+gdk-sys = "^0.18.0"
+gio = "^0.18.0"
+gio-sys = "^0.18.0"
+glib = "^0.18.0"
+glib-sys = "^0.18.0"
+gobject-sys = "^0.18.0"
+gtk = "^0.18.0"
+gtk-sys = "^0.18.0"
 
-  [dependencies.java_script_core]
-  package = "javascriptcore-rs"
-  version = "1.0"
+[dependencies.java_script_core]
+package = "javascriptcore-rs"
+version = "1.0"
 
-  [dependencies.soup]
-  package = "soup3"
-  version = "0.3"
+[dependencies.soup]
+package = "soup3"
+version = "0.5"
 
-  [dependencies.ffi]
-  package = "webkit2gtk-sys"
-  path = "sys"
-  version = "1.0"
+[dependencies.ffi]
+package = "webkit2gtk-sys"
+path = "sys"
+version = "1.0"

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -84,27 +84,27 @@ libc = "0.2"
 
   [dependencies.gtk]
   package = "gtk-sys"
-  version = "0.16"
+  version = "0.18"
 
   [dependencies.gdk]
   package = "gdk-sys"
-  version = "0.16"
+  version = "0.18"
 
   [dependencies.gio]
   package = "gio-sys"
-  version = "0.16"
+  version = "0.18"
 
   [dependencies.glib]
   package = "glib-sys"
-  version = "0.16"
+  version = "0.18"
 
   [dependencies.gobject]
   package = "gobject-sys"
-  version = "0.16"
+  version = "0.18"
 
   [dependencies.cairo]
   package = "cairo-sys-rs"
-  version = "0.16"
+  version = "0.18"
 
   [dependencies.java_script_core]
   package = "javascriptcore-rs-sys"
@@ -112,7 +112,7 @@ libc = "0.2"
 
   [dependencies.soup]
   package = "soup3-sys"
-  version = "0.3"
+  version = "0.5"
 
 [dev-dependencies]
 shell-words = "1.0.0"
@@ -120,13 +120,6 @@ tempfile = "3"
 
 [features]
 dox = [
-  "gtk/dox",
-  "glib/dox",
-  "gobject/dox",
-  "gio/dox",
-  "gdk/dox",
-  "cairo/dox",
-  "soup/dox",
   "java_script_core/dox"
 ]
 v2_6 = [ ]


### PR DESCRIPTION
Bumps Version of gtk related libraries to v0.18 to support a feature on the main tauri repo mentioned here: 
https://github.com/tauri-apps/tauri/issues/7855

