### PR TITLE
Exclude a development script

### DIFF
--- a/.changes/exclude_scripts.md
+++ b/.changes/exclude_scripts.md
@@ -1,0 +1,6 @@
+---
+"webkit2gtk-sys": patch
+"webkit2gtk-rs": patch
+---
+
+Exclude development scripts from the published packages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Rust bindings for webkit-gtk library"
 repository = "https://github.com/tauri-apps/webkit2gtk-rs"
 license = "MIT"
 keywords = [ "webkit", "gtk-rs", "gnome", "GUI" ]
+include = ["README.md", "LICENSE", "src/**/*.rs", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -9,6 +9,7 @@ links = "web_kit2"
 repository = "https://github.com/tauri-apps/webkit2gtk-rs"
 version = "2.0.1"
 edition = "2018"
+include = ["README.md", "LICENSE", "src/**/*.rs", "build.rs", "CHANGELOG.md"]
 
 [package.metadata.docs.rs]
 rustc-args = [ "--cfg", "docsrs" ]


### PR DESCRIPTION
During a dependency review we noticed that the webkit2gtk crate includes a development script. This development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from beeing included in the published packages to make sure that everything that's included is an conscious choice.

<!--
Before submitting a PR, please read https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines

1. Give the PR a descriptive title.

  Examples of good title:
    - fix: fix race condition in WebView
    - docs: update docstrings
    - feat: update bindings 

  Examples of bad title:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR text, e.g. closes #123.
3. If this change requires a new version, then add a change file in `.changes` directory with the appropriate bump, see https://github.com/tauri-apps/webkit2gtk-rs/blob/dev/.changes/readme.md
4. Ensure that all your commits are signed https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
5. Ensure `cargo test` passes.
6. Open as a draft PR if your work is still in progress.
-->
