### PR TITLE
chore: update bitflags dependency version to 2.0

### DIFF
--- a/.changes/update-bitflags-to-2-0.md
+++ b/.changes/update-bitflags-to-2-0.md
@@ -1,0 +1,8 @@
+---
+"webkit2gtk": patch
+---
+
+Update bitflags dependency version to 2.0.
+
+This avoids duplicated dependencies in downstream crates.
+

--- a/.changes/update-bitflags-to-2-0.md
+++ b/.changes/update-bitflags-to-2-0.md
@@ -1,5 +1,6 @@
 ---
-"webkit2gtk": patch
+"webkit2gtk-rs": patch
+"webkit2gtk-sys": patch
 ---
 
 Update bitflags dependency version to 2.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ v2_38 = [ "v2_36", "ffi/v2_38" ]
 v2_40 = [ "v2_38", "ffi/v2_40" ]
 
 [dependencies]
-bitflags = "^1.0"
+bitflags = "^2.0"
 once_cell = "1.8"
 libc = "^0.2"
 cairo-rs = "^0.18.0"

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -82,7 +82,7 @@ pkg-config = "0.3.7"
 system-deps = "6"
 
 [dependencies]
-bitflags = "^1.0"
+bitflags = "^2.0"
 libc = "0.2"
 
   [dependencies.gtk]


### PR DESCRIPTION
This avoids duplicated dependencies in downstream crates.